### PR TITLE
Update file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,10 @@ A corpus-reader extension for CLTK
 `pip install -e git+https://github.com/diyclassics/cltk_readers.git#egg=cltk_readers`
 
 ## Usage
-NB: You need to have the path and a regex for matching filenames to use the readers.
-
 ```
 >>> from os.path import expanduser
 >>> from cltkreaders.lat import LatinTesseraeCorpusReader
->>> CLTK_DATA_PATH = expanduser('~/cltk_data/lat/text/lat_text_tesserae/texts')
->>> TESS_PATTERN = '.*\.tess'
->>> tess = LatinTesseraeCorpusReader(CLTK_DATA_PATH, TESS_PATTERN)
+>>> tess = LatinTesseraeCorpusReader()
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,18 +27,18 @@ NB: You need to have the path and a regex for matching filenames to use the read
 
 ```
 >>> pprint(next(tess.concordance('vergil.aeneid.part.1.tess')))
-...
- ('sensit', [('<verg. aen. 1.125>', 2)]),
- ('sententia',
-  [('<verg. aen. 1.237>', 4),
-   ('<verg. aen. 1.260>', 4),
-   ('<verg. aen. 1.582>', 5)]),
- ('septem',
-  [('<verg. aen. 1.71>', 3),
-   ('<verg. aen. 1.170>', 1),
-   ('<verg. aen. 1.192>', 4),
-   ('<verg. aen. 1.383>', 1)]),
-...
+{
+  ...
+  'sensit': [('<verg. aen. 1.125>', 2)],
+  'sententia': [('<verg. aen. 1.237>', 4),
+               ('<verg. aen. 1.260>', 4),
+               ('<verg. aen. 1.582>', 5)],
+  'septem': [('<verg. aen. 1.71>', 3),
+            ('<verg. aen. 1.170>', 1),
+            ('<verg. aen. 1.192>', 4),
+            ('<verg. aen. 1.383>', 1)],
+  ...
+}
 ```
 
 ## Corpora supported (so far!)

--- a/cltkreaders/grc.py
+++ b/cltkreaders/grc.py
@@ -48,7 +48,7 @@ class GreekTesseraeCorpusReader(TesseraeCorpusReader):
                                       sent_tokenizer=self.sent_tokenizer)
     
     def pos_sents(self, fileids: Union[list, str] = None, preprocess: Callable = None) -> Iterator[list]:
-        for sent in self.sents():
+        for sent in self.sents(fileids):
             data = self.nlp.analyze(text=sent)
             pos_sent = []
             for item in data:

--- a/cltkreaders/lat.py
+++ b/cltkreaders/lat.py
@@ -6,7 +6,7 @@ __license__ = "MIT License."
 
 from typing import Callable, Iterator, Union
 
-from cltkreaders.readers import TesseraeCorpusReader
+from readers import TesseraeCorpusReader
 
 from cltk import NLP
 from cltk.core.data_types import Pipeline
@@ -50,7 +50,7 @@ class LatinTesseraeCorpusReader(TesseraeCorpusReader):
                                       sent_tokenizer=self.sent_tokenizer)
 
     def pos_sents(self, fileids: Union[list, str] = None, preprocess: Callable = None) -> Iterator[list]:
-        for sent in self.sents():
+        for sent in self.sents(fileids):
             data = self.nlp.analyze(text=sent)
             pos_sent = []
             for item in data:

--- a/cltkreaders/lat.py
+++ b/cltkreaders/lat.py
@@ -4,6 +4,7 @@
 __author__ = ["Patrick J. Burns <patrick@diyclassics.org>",]
 __license__ = "MIT License."
 
+import os.path
 from typing import Callable, Iterator, Union
 
 from readers import TesseraeCorpusReader
@@ -16,12 +17,16 @@ from cltk.dependency.processes import LatinStanzaProcess
 from cltk.sentence.lat import LatinPunktSentenceTokenizer
 from cltk.tokenizers.lat.lat import LatinWordTokenizer
 
+from cltk.utils import get_cltk_data_dir, query_yes_no
+from cltk.data.fetch import FetchCorpus
+from cltk.core.exceptions import CLTKException
+
 class LatinTesseraeCorpusReader(TesseraeCorpusReader):
     """
     A corpus reader for Latin texts from the Tesserae-CLTK corpus
     """
 
-    def __init__(self, root: str, fileids: str = None, encoding: str = 'utf-8', lang: str = 'lat',
+    def __init__(self, root: str = None, fileids: str = r'.*\.tess', encoding: str = 'utf-8', lang: str = 'lat',
                  normalization_form: str = 'NFC',
                  word_tokenizer: Callable = None, sent_tokenizer: Callable = None, **kwargs):
         """
@@ -33,6 +38,11 @@ class LatinTesseraeCorpusReader(TesseraeCorpusReader):
         :param kwargs: Miscellaneous keyword arguments
         """
         self.lang = lang
+        self.corpus = "lat_text_tesserae"
+        self._root = root
+
+        self.check_corpus()
+
         pipeline = Pipeline(description="Latin pipeline for Tesserae readers", 
                             processes=[LatinNormalizeProcess, LatinStanzaProcess], 
                             language=get_lang(self.lang))
@@ -43,11 +53,43 @@ class LatinTesseraeCorpusReader(TesseraeCorpusReader):
             self.word_tokenizer = LatinWordTokenizer()
         if not sent_tokenizer:
             self.sent_tokenizer = LatinPunktSentenceTokenizer()
-
         
-        TesseraeCorpusReader.__init__(self, root, fileids, encoding, self.lang,
+        TesseraeCorpusReader.__init__(self, self.root, fileids, encoding, self.lang,
                                       word_tokenizer=self.word_tokenizer,
                                       sent_tokenizer=self.sent_tokenizer)
+
+    @property
+    def root(self):
+        if not self._root:
+            self._root = os.path.join(
+                            get_cltk_data_dir(),
+                            f"{self.lang}/text/{self.corpus}/texts")
+        return self._root
+
+    def check_corpus(self):
+        if not os.path.isdir(self.root):
+            if self.root != os.path.join(
+                    get_cltk_data_dir(),
+                    f"{self.lang}/text/{self.corpus}/texts"):
+                raise CLTKException(
+                    f"Failed to instantiate LatinTesseraeCorpusReader. Root folder not found."
+                )                        
+            else:
+                print(  # pragma: no cover
+                    f"CLTK message: Unless a path is specifically passed to the 'root' parameter, this corpus reader expects to find the CLTK-Tesserae texts at {f'{self.lang}/text/{self.lang}_text_tesserae/texts'}."
+                )  # pragma: no cover
+                dl_is_allowed = query_yes_no(
+                    f"Do you want to download CLTK-Tesserae Latin files?"
+                )  # type: bool
+                if dl_is_allowed:
+                    fetch_corpus = FetchCorpus(language=self.lang)
+                    fetch_corpus.import_corpus(
+                        corpus_name=self.corpus
+                    )
+                else:
+                    raise CLTKException(
+                        f"Failed to instantiate LatinTesseraeCorpusReader. Rerun with 'root' parameter set to folder with .tess files or download the corpus to the CLTK_DATA folder."
+                    )        
 
     def pos_sents(self, fileids: Union[list, str] = None, preprocess: Callable = None) -> Iterator[list]:
         for sent in self.sents(fileids):

--- a/cltkreaders/readers.py
+++ b/cltkreaders/readers.py
@@ -131,7 +131,7 @@ class TesseraeCorpusReader(PlaintextCorpusReader):
         for doc_row in self.doc_rows(fileids):
             text = '\n'.join(doc_row.values())
             if preprocess:
-                text = preprocess(self, text)
+                text = preprocess(text)
             yield text
 
     def sents(self, fileids: Union[list, str] = None, preprocess: Callable = None,
@@ -148,7 +148,7 @@ class TesseraeCorpusReader(PlaintextCorpusReader):
                 sents = [sent.replace('\n', ' ') for sent in sents]
             for sent in sents:
                 if preprocess:
-                    yield preprocess(self, sent)
+                    yield preprocess(sent)
                 else:
                     yield sent
 
@@ -202,7 +202,7 @@ class TesseraeCorpusReader(PlaintextCorpusReader):
             items = doc_row.items()
             for citation, text in items:
                 if preprocess:
-                    text = preprocess(self, text)
+                    text = preprocess(text)
                 text_tokens = text.split()
                 for i, token in enumerate(text_tokens):
                     if compiled:

--- a/notebooks/tesserae-demo.ipynb
+++ b/notebooks/tesserae-demo.ipynb
@@ -18,32 +18,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ## Download corpus/corpora\n",
-    "# # NB: Uncomment if you do not have the corpora already installed\n",
-    "\n",
-    "# # For more information about working with CLTK corpora:\n",
-    "# # https://docs.cltk.org/en/latest/data.html\n",
-    "\n",
-    "# from cltk.data.fetch import FetchCorpus\n",
-    "# corpus_downloader.import_corpus('lat_text_tesserae')\n",
-    "# corpus_downloader.import_corpus(\"lat_models_cltk\")"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "## Set up reader\n",
+    "# NB: If you do not have the CLTK-Tesserae corpus already installed in CLTK_DATA, you will be prompted to download the corpus.\n",
     "\n",
-    "CLTK_DATA_PATH = expanduser('~/cltk_data/lat/text/lat_text_tesserae/texts')\n",
-    "TESS_PATTERN = '.*\\.tess'\n",
-    "T = LatinTesseraeCorpusReader(CLTK_DATA_PATH, TESS_PATTERN)"
+    "T = LatinTesseraeCorpusReader()"
    ]
   },
   {
@@ -574,7 +556,7 @@
      "text": [
       "{'files': 748,\n",
       " 'lexdiv': 24.255701516259066,\n",
-      " 'secs': 146.6567120552063,\n",
+      " 'secs': 143.71532320976257,\n",
       " 'sents': 314436,\n",
       " 'vocab': 329693,\n",
       " 'words': 7996935}\n"
@@ -600,7 +582,7 @@
       "Stats on just the file 'catullus.carmina.tess'\n",
       "{'files': 1,\n",
       " 'lexdiv': 2.6641561109209175,\n",
-      " 'secs': 0.26555800437927246,\n",
+      " 'secs': 0.2310171127319336,\n",
       " 'sents': 679,\n",
       " 'vocab': 5842,\n",
       " 'words': 15564}\n"
@@ -626,7 +608,7 @@
       "Stats on just the group of files assigned above to the variable `metamorphoses`\n",
       "{'files': 15,\n",
       " 'lexdiv': 5.029560639805629,\n",
-      " 'secs': 1.4292857646942139,\n",
+      " 'secs': 1.3825619220733643,\n",
       " 'sents': 4362,\n",
       " 'vocab': 19756,\n",
       " 'words': 99364}\n"
@@ -658,7 +640,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.9.10"
   },
   "orig_nbformat": 4
  },

--- a/notebooks/tesserae-demo.ipynb
+++ b/notebooks/tesserae-demo.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Imports\n",
+    "## Imports\n",
     "\n",
     "import os, sys; sys.path.append(os.path.dirname(os.path.realpath('../cltkreaders/lat.py')))\n",
     "from lat import LatinTesseraeCorpusReader\n",
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # Download corpus/corpora\n",
+    "# ## Download corpus/corpora\n",
     "# # NB: Uncomment if you do not have the corpora already installed\n",
     "\n",
     "# # For more information about working with CLTK corpora:\n",
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set up reader\n",
+    "## Set up reader\n",
     "\n",
     "CLTK_DATA_PATH = expanduser('~/cltk_data/lat/text/lat_text_tesserae/texts')\n",
     "TESS_PATTERN = '.*\\.tess'\n",
@@ -67,7 +67,7 @@
     }
    ],
    "source": [
-    "# First 10 filesnames\n",
+    "## First 10 filesnames\n",
     "\n",
     "print(T.fileids()[:10])"
    ]
@@ -86,7 +86,7 @@
     }
    ],
    "source": [
-    "# First 10 works of Cicero\n",
+    "## First 10 works of Cicero\n",
     "\n",
     "cicero = [file for file in T.fileids() if 'cicero' in file]\n",
     "print(cicero[:10])"
@@ -106,7 +106,7 @@
     }
    ],
    "source": [
-    "# Books of the Aeneid, sorted\n",
+    "## Books of the Aeneid, sorted\n",
     "\n",
     "aeneid = natsorted([file for file in T.fileids() if 'aeneid' in file])\n",
     "print(aeneid)"
@@ -237,6 +237,15 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "catilinam = 'cicero.in_catilinam.tess'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -247,18 +256,9 @@
     }
    ],
    "source": [
-    "# Paras\n",
+    "## Paras\n",
     "\n",
     "print(\"Note that for the Tesserae texts, `paras` are *not* implemented. As they are not consistent marked in the original files.\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "catilinam = 'cicero.in_catilinam.tess'"
    ]
   },
   {
@@ -396,7 +396,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "POS Sent 1: ['Galli/NOUN', 'Caesaris/NOUN', 'saevitia/NOUN', './PUNCT']\n"
+      "POS Sent 1: ['quo/PRON', 'usque/ADP', 'tandem/ADV', 'abutere/VERB', ',/PUNCT', 'Catilina/NOUN', ',/PUNCT', 'patientia/NOUN', 'nostra/DET', '?/PUNCT']\n"
      ]
     }
    ],
@@ -540,7 +540,7 @@
       "Here are the first five instances...\n",
       "[('<ov. met. 1.190>', 5), ('<ov. met. 2.362>', 6), ('<ov. met. 2.611>', 0), ('<ov. met. 2.647>', 2), ('<ov. met. 2.648>', 2)]\n",
       "\n",
-      "'corpus' appears 86 times in the Metamorphoses.\n",
+      "'corpora' appears 86 times in the Metamorphoses.\n",
       "Here are the first five instances...\n",
       "[('<ov. met. 1.2>', 0), ('<ov. met. 1.156>', 4), ('<ov. met. 1.300>', 5), ('<ov. met. 1.527>', 5), ('<ov. met. 2.235>', 4)]\n"
      ]
@@ -558,7 +558,7 @@
     "\n",
     "print()\n",
     "\n",
-    "print(f'\\'corpus\\' appears {len(full_met_conc_sample[\"corpora\"])} times in the Metamorphoses.')\n",
+    "print(f'\\'corpora\\' appears {len(full_met_conc_sample[\"corpora\"])} times in the Metamorphoses.')\n",
     "print('Here are the first five instances...')\n",
     "print(full_met_conc_sample['corpora'][:5])"
    ]
@@ -574,7 +574,7 @@
      "text": [
       "{'files': 748,\n",
       " 'lexdiv': 24.255701516259066,\n",
-      " 'secs': 148.65790390968323,\n",
+      " 'secs': 146.6567120552063,\n",
       " 'sents': 314436,\n",
       " 'vocab': 329693,\n",
       " 'words': 7996935}\n"
@@ -600,7 +600,7 @@
       "Stats on just the file 'catullus.carmina.tess'\n",
       "{'files': 1,\n",
       " 'lexdiv': 2.6641561109209175,\n",
-      " 'secs': 0.24940991401672363,\n",
+      " 'secs': 0.26555800437927246,\n",
       " 'sents': 679,\n",
       " 'vocab': 5842,\n",
       " 'words': 15564}\n"
@@ -626,7 +626,7 @@
       "Stats on just the group of files assigned above to the variable `metamorphoses`\n",
       "{'files': 15,\n",
       " 'lexdiv': 5.029560639805629,\n",
-      " 'secs': 1.4473812580108643,\n",
+      " 'secs': 1.4292857646942139,\n",
       " 'sents': 4362,\n",
       " 'vocab': 19756,\n",
       " 'words': 99364}\n"

--- a/notebooks/tesserae-demo.ipynb
+++ b/notebooks/tesserae-demo.ipynb
@@ -396,7 +396,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "POS Sent 1: ['quo/PRON', 'usque/ADP', 'tandem/ADV', 'abutere/VERB', ',/PUNCT', 'Catilina/NOUN', ',/PUNCT', 'patientia/NOUN', 'nostra/DET', '?/PUNCT']\n"
+      "POS Sent 1: ['Galli/NOUN', 'Caesaris/NOUN', 'saevitia/NOUN', './PUNCT']\n"
      ]
     }
    ],
@@ -414,7 +414,229 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "## Doc description"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metamorphoses = natsorted([file for file in T.fileids() if 'ovid.metamorphoses' in file])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def custom_preprocess(text):\n",
+    "    from cltk.alphabet.lat import JVReplacer\n",
+    "    replacer = JVReplacer()\n",
+    "\n",
+    "    text = text.lower() # Lowercase\n",
+    "    text = replacer.replace(text)  # Normalize u/v & i/j\n",
+    "\n",
+    "    # Remove punctuation\n",
+    "    punctuation =\"\\\"#$%&\\'()*+,/:;<=>@[\\]^_`{|}~.?!«»—“-”\"\n",
+    "    misc = '¡£¤¥¦§¨©¯°±²³´µ¶·¸¹º¼½¾¿÷·–‘’†•ↄ∞⏑〈〉（）'\n",
+    "    misc += punctuation\n",
+    "    translator = str.maketrans({key: \" \" for key in misc})\n",
+    "    text = text.translate(translator)\n",
+    "\n",
+    "    # Remove numbers\n",
+    "    translator = str.maketrans({key: \" \" for key in '0123456789'})\n",
+    "    text = text.translate(translator)\n",
+    "\n",
+    "    return \" \".join(text.split()).strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('a', [('<ov. met. 1.145>', 2), ('<ov. met. 1.587>', 1)]),\n",
+      " ('ab',\n",
+      "  [('<ov. met. 1.3>', 3),\n",
+      "   ('<ov. met. 1.23>', 4),\n",
+      "   ('<ov. met. 1.34>', 5),\n",
+      "   ('<ov. met. 1.40>', 5),\n",
+      "   ('<ov. met. 1.66>', 4),\n",
+      "   ('<ov. met. 1.80>', 5),\n",
+      "   ('<ov. met. 1.144>', 5),\n",
+      "   ('<ov. met. 1.185>', 7),\n",
+      "   ('<ov. met. 1.233>', 4),\n",
+      "   ('<ov. met. 1.254>', 6),\n",
+      "   ('<ov. met. 1.269>', 5),\n",
+      "   ('<ov. met. 1.313>', 4),\n",
+      "   ('<ov. met. 1.336>', 6),\n",
+      "   ('<ov. met. 1.417>', 6),\n",
+      "   ('<ov. met. 1.431>', 2),\n",
+      "   ('<ov. met. 1.568>', 6),\n",
+      "   ('<ov. met. 1.607>', 5),\n",
+      "   ('<ov. met. 1.672>', 6),\n",
+      "   ('<ov. met. 1.774>', 7)]),\n",
+      " ('aberant', [('<ov. met. 1.91>', 2)])]\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Concordance, using Tesserae citations\n",
+    "\n",
+    "metamorphoses_concordances = T.concordance(metamorphoses, preprocess=custom_preprocess)\n",
+    "\n",
+    "met_conc_sample = next(metamorphoses_concordances)\n",
+    "pprint(list(met_conc_sample.items())[:3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('accensis', [('<ov. met. 12.12>', 2)]),\n",
+      " ('accensum', [('<ov. met. 2.228>', 1)]),\n",
+      " ('accensus', [('<ov. met. 11.527>', 4)]),\n",
+      " ('acceperat', [('<ov. met. 3.121>', 5)]),\n",
+      " ('accepere', [('<ov. met. 9.719>', 0), ('<ov. met. 15.641>', 4)]),\n",
+      " ('accepisse',\n",
+      "  [('<ov. met. 6.357>', 0),\n",
+      "   ('<ov. met. 14.844>', 4),\n",
+      "   ('<ov. met. 15.481>', 0)])]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Concordances are by default built on a file-by-file basis, but can easily be combined with the `compiled` parameter\n",
+    "\n",
+    "metamorphoses_concordances = T.concordance(metamorphoses, compiled=True, preprocess=custom_preprocess)\n",
+    "\n",
+    "full_met_conc_sample = next(metamorphoses_concordances)\n",
+    "pprint(list(full_met_conc_sample.items())[96:102])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'corpus' appears 67 times in the Metamorphoses.\n",
+      "Here are the first five instances...\n",
+      "[('<ov. met. 1.190>', 5), ('<ov. met. 2.362>', 6), ('<ov. met. 2.611>', 0), ('<ov. met. 2.647>', 2), ('<ov. met. 2.648>', 2)]\n",
+      "\n",
+      "'corpus' appears 86 times in the Metamorphoses.\n",
+      "Here are the first five instances...\n",
+      "[('<ov. met. 1.2>', 0), ('<ov. met. 1.156>', 4), ('<ov. met. 1.300>', 5), ('<ov. met. 1.527>', 5), ('<ov. met. 2.235>', 4)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Since the concordances are output as dictionaries, you can retrieve location information using the token as a dict key...\n",
+    "\n",
+    "metamorphoses_concordances = T.concordance(metamorphoses, compiled=True, preprocess=custom_preprocess)\n",
+    "full_met_conc_sample = next(metamorphoses_concordances)\n",
+    "\n",
+    "print(f'\\'corpus\\' appears {len(full_met_conc_sample[\"corpus\"])} times in the Metamorphoses.')\n",
+    "print('Here are the first five instances...')\n",
+    "print(full_met_conc_sample['corpus'][:5])\n",
+    "\n",
+    "print()\n",
+    "\n",
+    "print(f'\\'corpus\\' appears {len(full_met_conc_sample[\"corpora\"])} times in the Metamorphoses.')\n",
+    "print('Here are the first five instances...')\n",
+    "print(full_met_conc_sample['corpora'][:5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'files': 748,\n",
+      " 'lexdiv': 24.255701516259066,\n",
+      " 'secs': 148.65790390968323,\n",
+      " 'sents': 314436,\n",
+      " 'vocab': 329693,\n",
+      " 'words': 7996935}\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Basic descriptive data; note takes several minutes to run\n",
+    "\n",
+    "tess_describe = T.describe()\n",
+    "pprint(tess_describe)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stats on just the file 'catullus.carmina.tess'\n",
+      "{'files': 1,\n",
+      " 'lexdiv': 2.6641561109209175,\n",
+      " 'secs': 0.24940991401672363,\n",
+      " 'sents': 679,\n",
+      " 'vocab': 5842,\n",
+      " 'words': 15564}\n"
+     ]
+    }
+   ],
+   "source": [
+    "## This data can also be returned for individual files or lists of files\n",
+    "\n",
+    "print('Stats on just the file \\'catullus.carmina.tess\\'')\n",
+    "pprint(T.describe(catullus))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stats on just the group of files assigned above to the variable `metamorphoses`\n",
+      "{'files': 15,\n",
+      " 'lexdiv': 5.029560639805629,\n",
+      " 'secs': 1.4473812580108643,\n",
+      " 'sents': 4362,\n",
+      " 'vocab': 19756,\n",
+      " 'words': 99364}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Stats on just the group of files assigned above to the variable `metamorphoses`')\n",
+    "pprint(T.describe(metamorphoses))"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/tesserae-demo.ipynb
+++ b/notebooks/tesserae-demo.ipynb
@@ -1,0 +1,445 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports\n",
+    "\n",
+    "import os, sys; sys.path.append(os.path.dirname(os.path.realpath('../cltkreaders/lat.py')))\n",
+    "from lat import LatinTesseraeCorpusReader\n",
+    "\n",
+    "from os.path import expanduser\n",
+    "from natsort import natsorted\n",
+    "from pprint import pprint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # Download corpus/corpora\n",
+    "# # NB: Uncomment if you do not have the corpora already installed\n",
+    "\n",
+    "# # For more information about working with CLTK corpora:\n",
+    "# # https://docs.cltk.org/en/latest/data.html\n",
+    "\n",
+    "# from cltk.data.fetch import FetchCorpus\n",
+    "# corpus_downloader.import_corpus('lat_text_tesserae')\n",
+    "# corpus_downloader.import_corpus(\"lat_models_cltk\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up reader\n",
+    "\n",
+    "CLTK_DATA_PATH = expanduser('~/cltk_data/lat/text/lat_text_tesserae/texts')\n",
+    "TESS_PATTERN = '.*\\.tess'\n",
+    "T = LatinTesseraeCorpusReader(CLTK_DATA_PATH, TESS_PATTERN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fileids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['ammianus.rerum_gestarum.part.14.tess', 'ammianus.rerum_gestarum.part.15.tess', 'ammianus.rerum_gestarum.part.16.tess', 'ammianus.rerum_gestarum.part.17.tess', 'ammianus.rerum_gestarum.part.18.tess', 'ammianus.rerum_gestarum.part.19.tess', 'ammianus.rerum_gestarum.part.20.tess', 'ammianus.rerum_gestarum.part.21.tess', 'ammianus.rerum_gestarum.part.22.tess', 'ammianus.rerum_gestarum.part.23.tess']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# First 10 filesnames\n",
+    "\n",
+    "print(T.fileids()[:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['cicero.academica.tess', 'cicero.brutus.tess', 'cicero.cum_populo_gratias_egit.tess', 'cicero.de_amicitia.tess', 'cicero.de_divinatione.tess', 'cicero.de_domo_sua.tess', 'cicero.de_fato.tess', 'cicero.de_finibus_bonorum_et_malorum.part.1.tess', 'cicero.de_finibus_bonorum_et_malorum.part.2.tess', 'cicero.de_finibus_bonorum_et_malorum.part.3.tess']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# First 10 works of Cicero\n",
+    "\n",
+    "cicero = [file for file in T.fileids() if 'cicero' in file]\n",
+    "print(cicero[:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['vergil.aeneid.part.1.tess', 'vergil.aeneid.part.2.tess', 'vergil.aeneid.part.3.tess', 'vergil.aeneid.part.4.tess', 'vergil.aeneid.part.5.tess', 'vergil.aeneid.part.6.tess', 'vergil.aeneid.part.7.tess', 'vergil.aeneid.part.8.tess', 'vergil.aeneid.part.9.tess', 'vergil.aeneid.part.10.tess', 'vergil.aeneid.part.11.tess', 'vergil.aeneid.part.12.tess']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Books of the Aeneid, sorted\n",
+    "\n",
+    "aeneid = natsorted([file for file in T.fileids() if 'aeneid' in file])\n",
+    "print(aeneid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Doc structures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catullus = 'catullus.carmina.tess'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<cat. 1.1>\tCui dono lepidum novum libellum\n",
+      "<cat. 1.2>\tarido modo pumice expolitum?\n",
+      "<cat. 1.3>\tCorneli, tibi; namque tu solebas\n",
+      "<cat. 1.4>\tmeas esse aliquid putare nugas,\n",
+      "<cat. 1.5>\tiam tum cum ausus es unus Italorum\n",
+      "<cat. 1.6>\tomne aevum tribus explicare chartis,\n",
+      "<cat. 1.7>\tdoctis, Iuppiter, et laboriosis!\n",
+      "<cat. 1.8>\tquare habe tibi quidquid hoc libelli\n",
+      "<cat. 1.9>\tqualecumque, quod, o patrona virgo,\n",
+      "<cat. 1.10>\tplus uno maneat perenne saeclo.\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Docs\n",
+    "\n",
+    "catullus_doc = T.docs(catullus)\n",
+    "print(next(catullus_doc)[:446])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cui dono lepidum novum libellum\n",
+      "arido modo pumice expolitum?\n",
+      "Corneli, tibi; namque tu solebas\n",
+      "meas esse aliquid putare nugas,\n",
+      "iam tum cum ausus es unus Italorum\n",
+      "omne aevum tribus explicare chartis,\n",
+      "doctis, Iuppiter, et laboriosis!\n",
+      "quare habe tibi quidquid hoc libelli\n",
+      "qualecumque, quod, o patrona virgo,\n",
+      "plus uno maneat perenne saeclo.\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Texts\n",
+    "\n",
+    "catullus_text = T.texts(catullus)\n",
+    "print(next(catullus_text)[:335])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This is a string representation of what the output dictionary looks like...\n",
+      "{'<cat. 1.1>': 'Cui dono lepidum novum libellum', '<cat. 1.2>': 'arido modo pumice expolitum?' etc. }\n",
+      "\n",
+      "Here are the first 10 items of the dict output...\n",
+      "[('<cat. 1.1>', 'Cui dono lepidum novum libellum'),\n",
+      " ('<cat. 1.2>', 'arido modo pumice expolitum?'),\n",
+      " ('<cat. 1.3>', 'Corneli, tibi; namque tu solebas'),\n",
+      " ('<cat. 1.4>', 'meas esse aliquid putare nugas,'),\n",
+      " ('<cat. 1.5>', 'iam tum cum ausus es unus Italorum'),\n",
+      " ('<cat. 1.6>', 'omne aevum tribus explicare chartis,'),\n",
+      " ('<cat. 1.7>', 'doctis, Iuppiter, et laboriosis!'),\n",
+      " ('<cat. 1.8>', 'quare habe tibi quidquid hoc libelli'),\n",
+      " ('<cat. 1.9>', 'qualecumque, quod, o patrona virgo,'),\n",
+      " ('<cat. 1.10>', 'plus uno maneat perenne saeclo.')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Doc Rows\n",
+    "\n",
+    "catullus_docrows = T.doc_rows(catullus)\n",
+    "\n",
+    "print('This is a string representation of what the output dictionary looks like...')\n",
+    "print(f'{str(next(catullus_docrows))[:94]} etc. }}\\n')\n",
+    "\n",
+    "\n",
+    "catullus_docrows = T.doc_rows(catullus)\n",
+    "print('Here are the first 10 items of the dict output...')\n",
+    "pprint(list(next(catullus_docrows).items())[:10])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Doc units"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note that for the Tesserae texts, `paras` are *not* implemented. As they are not consistent marked in the original files.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Paras\n",
+    "\n",
+    "print(\"Note that for the Tesserae texts, `paras` are *not* implemented. As they are not consistent marked in the original files.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catilinam = 'cicero.in_catilinam.tess'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sent 1: quo usque tandem abutere, Catilina, patientia nostra?\n",
+      "Sent 2: quam diu etiam furor iste tuus nos eludet?\n",
+      "Sent 3: quem ad finem sese effrenata iactabit audacia?\n",
+      "Sent 4: nihilne te nocturnum praesidium Palati, nihil urbis vigiliae, nihil timor populi, nihil concursus bonorum omnium, nihil hic munitissimus habendi senatus locus, nihil horum ora voltusque moverunt?\n",
+      "Sent 5: patere tua consilia non sentis, constrictam iam horum omnium scientia teneri coniurationem tuam non vides?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Sents\n",
+    "\n",
+    "# NB: Sents are segmented by default with the CLTK LatinPunktSentenceTokenizer\n",
+    "\n",
+    "catilinam_sents = T.sents(catilinam)\n",
+    "\n",
+    "for i in range(1,6):\n",
+    "    print(f'Sent {i}: {next(catilinam_sents)}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Word 1: quo\n",
+      "Word 2: usque\n",
+      "Word 3: tandem\n",
+      "Word 4: abutere\n",
+      "Word 5: ,\n",
+      "Word 6: Catilina\n",
+      "Word 7: ,\n",
+      "Word 8: patientia\n",
+      "Word 9: nostra\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Words\n",
+    "\n",
+    "# NB: Words are tokenized by default with the CLTK LatinWordTokenizer\n",
+    "\n",
+    "catilinam_words = T.words(catilinam)\n",
+    "\n",
+    "for i in range(1,10):\n",
+    "    print(f'Word {i}: {next(catilinam_words)}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Word 1: quo\n",
+      "Word 2: usque\n",
+      "Word 3: tandem\n",
+      "Word 4: abutere\n",
+      "Word 5: ,\n",
+      "Word 6: catilina\n",
+      "Word 7: ,\n",
+      "Word 8: patientia\n",
+      "Word 9: nostra\n"
+     ]
+    }
+   ],
+   "source": [
+    "# You can pass a preprocessor to `words` \n",
+    "\n",
+    "def custom_preprocess(text):\n",
+    "    text = text.lower()\n",
+    "    return text\n",
+    "\n",
+    "catilinam_words = T.words(catilinam, preprocess=custom_preprocess)\n",
+    "\n",
+    "for i in range(1,10):\n",
+    "    print(f'Word {i}: {next(catilinam_words)}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tok Sent 1: ['quo', 'usque', 'tandem', 'abutere', ',', 'Catilina', ',', 'patientia', 'nostra', '?']\n",
+      "Tok Sent 2: ['quam', 'diu', 'etiam', 'furor', 'iste', 'tuus', 'nos', 'eludet', '?']\n",
+      "Tok Sent 3: ['quem', 'ad', 'finem', 'sese', 'effrenata', 'iactabit', 'audacia', '?']\n",
+      "Tok Sent 4: ['nihil', '-ne', 'te', 'nocturnum', 'praesidium', 'Palati', ',', 'nihil', 'urbis', 'vigiliae', ',', 'nihil', 'timor', 'populi', ',', 'nihil', 'concursus', 'bonorum', 'omnium', ',', 'nihil', 'hic', 'munitissimus', 'habendi', 'senatus', 'locus', ',', 'nihil', 'horum', 'ora', 'voltus', '-que', 'moverunt', '?']\n",
+      "Tok Sent 5: ['patere', 'tua', 'consilia', 'non', 'sentis', ',', 'constrictam', 'iam', 'horum', 'omnium', 'scientia', 'teneri', 'coniurationem', 'tuam', 'non', 'vides', '?']\n",
+      "Tok Sent 6: ['quid', 'proxima', ',', 'quid', 'superiore', 'nocte', 'egeris', ',', 'ubi', 'fueris', ',', 'quos', 'convocaveris', ',', 'quid', 'consili', 'ceperis', 'quem', 'nostrum', 'ignorare', 'arbitraris', '?']\n",
+      "Tok Sent 7: ['O', 'tempora', ',', 'o', 'mores', '!']\n",
+      "Tok Sent 8: ['senatus', 'haec', 'intellegit', ',', 'consul', 'videt', ';', 'hic', 'tamen', 'vivit', '.']\n",
+      "Tok Sent 9: ['vivit', '?']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tokenized sents\n",
+    "\n",
+    "# A combination of the two structures above; convenient for many applications that require lists of tokenized sentences\n",
+    "\n",
+    "catilinam_tokenized_sents = T.tokenized_sents(catilinam)\n",
+    "\n",
+    "for i in range(1,10):\n",
+    "    print(f'Tok Sent {i}: {next(catilinam_tokenized_sents)}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "POS Sent 1: ['quo/PRON', 'usque/ADP', 'tandem/ADV', 'abutere/VERB', ',/PUNCT', 'Catilina/NOUN', ',/PUNCT', 'patientia/NOUN', 'nostra/DET', '?/PUNCT']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# POS-tagged sents\n",
+    "\n",
+    "# NB: Tokens are POS-tagged by default with the CLTK LatinStanzaProcess; this cannot be currently customized\n",
+    "\n",
+    "catilinam_pos_sents = T.pos_sents(catilinam)\n",
+    "\n",
+    "for i in range(1,2):\n",
+    "    print(f'POS Sent {i}: {next(catilinam_pos_sents)}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "f13c6c4616355ccd51d0d099c0ff7de6feb31d3474457a6e0aa7c4b62d9c3be4"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.9 64-bit ('cltk_readers-dev': virtualenv)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Update default file locations, patterns for Latin and Greek Tesserae readers
- Removes need to set `root` parameter; by default, the reader will check CLTK_DATA for CLTK-Tesserae corpora
- Removes need to set `fileids`; by default, file pattern is set to r'.*\.tess'
- If corpus is not found in CLTK_DATA, interactive option is given to download corpus