### PR TITLE
Fix reader import

### DIFF
--- a/cltkreaders/grc.py
+++ b/cltkreaders/grc.py
@@ -7,7 +7,7 @@ __license__ = "MIT License."
 import os.path
 from typing import Callable, Iterator, Union
 
-from readers import TesseraeCorpusReader
+from cltkreaders.readers import TesseraeCorpusReader
 
 from cltk import NLP
 from cltk.core.data_types import Pipeline

--- a/cltkreaders/lat.py
+++ b/cltkreaders/lat.py
@@ -7,7 +7,7 @@ __license__ = "MIT License."
 import os.path
 from typing import Callable, Iterator, Union
 
-from readers import TesseraeCorpusReader
+from cltkreaders.readers import TesseraeCorpusReader
 
 from cltk import NLP
 from cltk.core.data_types import Pipeline


### PR DESCRIPTION
Updated so that language-specific imports include full path to module, e.g.
```from cltkreaders.readers import TesseraeCorpusReader```