### PR TITLE
Miscellaneous fixes from Issue #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # CLTK Readers
 A corpus-reader extension for CLTK
 
+Version 0.2.0.; tested on Python 3.9.10, CLTK 1.0.22
+
 ## Installation
 `pip install -e git+https://github.com/diyclassics/cltk_readers.git#egg=cltk_readers`
 
@@ -39,3 +41,5 @@ A corpus-reader extension for CLTK
 ## Corpora supported (so far!)
 - [CLTK Tesserae Latin Corpus](https://github.com/cltk/lat_text_tesserae)
 - [CLTK Tesserae Greek Corpus](https://github.com/cltk/grc_text_tesserae)
+
+*Coded 2.9.2022 by [Patrick J. Burns](http://github.com/diyclassics)*

--- a/cltkreaders/grc.py
+++ b/cltkreaders/grc.py
@@ -41,7 +41,7 @@ class GreekTesseraeCorpusReader(TesseraeCorpusReader):
         self.corpus = "grc_text_tesserae"
         self._root = root
 
-        self.check_corpus()
+        self.__check_corpus()
 
         pipeline = Pipeline(description="Greek pipeline for Tesserae readers", 
                             processes=[GreekNormalizeProcess, GreekStanzaProcess], 
@@ -70,7 +70,7 @@ class GreekTesseraeCorpusReader(TesseraeCorpusReader):
                             f"{self.lang}/text/{self.corpus}/texts")
         return self._root
 
-    def check_corpus(self):
+    def __check_corpus(self):
         print(f'ROOT = {self.root}')
         if not os.path.isdir(self.root):
             if self.root != os.path.join(

--- a/cltkreaders/lat.py
+++ b/cltkreaders/lat.py
@@ -41,7 +41,7 @@ class LatinTesseraeCorpusReader(TesseraeCorpusReader):
         self.corpus = "lat_text_tesserae"
         self._root = root
 
-        self.check_corpus()
+        self.__check_corpus()
 
         
         pipeline = Pipeline(description="Latin pipeline for Tesserae readers", 
@@ -72,7 +72,7 @@ class LatinTesseraeCorpusReader(TesseraeCorpusReader):
                             f"{self.lang}/text/{self.corpus}/texts")
         return self._root
 
-    def check_corpus(self):
+    def __check_corpus(self):
         if not os.path.isdir(self.root):
             if self.root != os.path.join(
                     get_cltk_data_dir(),

--- a/cltkreaders/readers.py
+++ b/cltkreaders/readers.py
@@ -7,6 +7,7 @@ __author__ = ["Patrick J. Burns <patrick@diyclassics.org>",]
 __license__ = "MIT License."
 
 import os
+import warnings
 import codecs
 import unicodedata
 import time
@@ -44,7 +45,8 @@ class TesseraeCorpusReader(PlaintextCorpusReader):
         """
 
         # Tesserae readers at present are limited to support for Greek and Latin; check on instantiation
-        lang = lang.lower()
+        if lang:
+            self.lang = lang.lower()
 
         if lang is None:
             if 'greek' in root or 'grc' in root:
@@ -116,10 +118,13 @@ class TesseraeCorpusReader(PlaintextCorpusReader):
 
             lines = [line for line in doc.split('\n') if line]
             for line in lines:
-                k, v = line.split('>', 1)
-                k = f'{k}>'
-                v = v.strip()
-                rows.append((k, v))
+                try:
+                    k, v = line.split('>', 1)
+                    k = f'{k}>'
+                    v = v.strip()
+                    rows.append((k, v))
+                except:
+                    print(f'The following line is not formatted corrected and has been skipped: {line}\n')
             yield dict(rows)
 
     def texts(self, fileids: Union[list, str] = None, preprocess: Callable = None) -> Iterator[str]:
@@ -217,6 +222,14 @@ class TesseraeCorpusReader(PlaintextCorpusReader):
         else:
             for doc_rows in self.doc_rows(fileids):
                 yield dict(build_concordance(doc_rows))
+
+    def citation(self):
+        with open(f'{self.root}/../citation.bib', 'r') as f:
+            return f.read()   
+
+    def license(self):
+        with open(f'{self.root}/../LICENSE.md', 'r') as f:
+            return f.read()               
 
     def sizes(self, fileids: Union[list, str] = None) -> Iterator[int]:
         """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='cltk_readers',
-    version='0.2.0',
+    version='0.2.1',
     packages=['cltkreaders'],
     url='https://github.com/diyclassics/cltk_readers',
     license='MIT License',

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup
 
 setup(
     name='cltk_readers',
-    version='0.1.1',
+    version='0.2.0',
     packages=['cltkreaders'],
     url='https://github.com/diyclassics/cltk_readers',
     license='MIT License',
     author='Patrick J. Burns',
     author_email='patrick@diyclassics.org',
     description='Corpus reader extension for the Classical Language Toolkit ',
-    install_requires=['cltk~=1.0.15',
+    install_requires=['cltk~=1.0.22',
                       'pyuca==1.2',
     ],
     classifiers=[


### PR DESCRIPTION
    - Change `check_corpus` to private method in `lat.py` and `grc.py`
    - Fix `license` and `citation` methods for Tesserae reader
    - Add formatting check to `doc_rows` method; skip incorrectly formatted lines
    - Bump version to 0.2.1
    - Closes #11